### PR TITLE
front-18: create history page

### DIFF
--- a/frontend/extension/src/popup/pages/History.tsx
+++ b/frontend/extension/src/popup/pages/History.tsx
@@ -1,0 +1,499 @@
+import React, { useState } from 'react';
+
+interface HistoryProps {
+  onBack?: () => void;
+  onNavigateToPlans?: () => void;
+}
+
+const History: React.FC<HistoryProps> = ({ onBack, onNavigateToPlans }) => {
+  const [currentPage, setCurrentPage] = useState(3);
+  const [isFreePlan] = useState(true); // Simulate Free plan
+
+  // Mock data for transactions
+  const allTransactions = [
+    {
+      id: '1',
+      address: '0xAb3...F9c2',
+      amount: '2.5 ETH',
+      network: 'Ethereum',
+      risk: 85,
+      date: '25/20/01 14:32',
+      status: 'blocked'
+    },
+    {
+      id: '2',
+      address: '0xAb3...F9c2',
+      amount: '2.5 ETH',
+      network: 'Ethereum',
+      risk: 85,
+      date: '25/20/01 14:32',
+      status: 'blocked'
+    },
+    {
+      id: '3',
+      address: '0x742...A8b1',
+      amount: '0.8 ETH',
+      network: 'Ethereum',
+      risk: 15,
+      date: '25/20/01 14:32',
+      status: 'approved'
+    },
+    {
+      id: '4',
+      address: '0x5F2...C3d4',
+      amount: '1.2 ETH',
+      network: 'Ethereum',
+      risk: 45,
+      date: '25/20/01 14:32',
+      status: 'warning'
+    },
+    {
+      id: '5',
+      address: '0x742...A8b1',
+      amount: '0.8 ETH',
+      network: 'Ethereum',
+      risk: 15,
+      date: '25/20/01 14:32',
+      status: 'approved'
+    },
+    {
+      id: '6',
+      address: '0x6A7...B5e9',
+      amount: '0.8 ETH',
+      network: 'Bitcoin',
+      risk: 30,
+      date: '25/20/01 15:00',
+      status: 'warning'
+    },
+    {
+      id: '7',
+      address: '0xAb3...F9c2',
+      amount: '2.5 ETH',
+      network: 'Ethereum',
+      risk: 85,
+      date: '25/20/01 14:32',
+      status: 'blocked'
+    },
+    {
+      id: '8',
+      address: '0x8F4...D1a2',
+      amount: '2.1 ETH',
+      network: 'Ripple',
+      risk: 50,
+      date: '25/20/01 15:30',
+      status: 'warning'
+    },
+    {
+      id: '9',
+      address: '0x9D2...F8c7',
+      amount: '3.0 ETH',
+      network: 'Litecoin',
+      risk: 20,
+      date: '25/20/01 16:00',
+      status: 'warning'
+    },
+    {
+      id: '10',
+      address: '0xA3B...E4f5',
+      amount: '1.5 ETH',
+      network: 'Cardano',
+      risk: 40,
+      date: '25/20/01 16:30',
+      status: 'warning'
+    }
+  ];
+
+  // Filter transactions based on plan
+  const transactions = isFreePlan ? allTransactions.slice(0, 3) : allTransactions;
+
+  const getStatusIcon = (status: string) => {
+    switch (status) {
+      case 'blocked':
+        return (
+          <img
+            src="/assets/icon-forbidden.svg"
+            alt="Blocked"
+            className="w-4 h-4"
+          />
+        );
+      case 'approved':
+        return (
+          <img
+            src="/assets/icon-success.svg"
+            alt="Approved"
+            className="w-4 h-4"
+          />
+        );
+      case 'warning':
+        return (
+          <img
+            src="/assets/icon-droplet.svg"
+            alt="Warning"
+            className="w-4 h-4"
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  const getRiskColor = (risk: number) => {
+    if (risk >= 70) return '#FF4444'; // Red
+    if (risk >= 40) return '#FF8800'; // Orange
+    return '#00D386'; // Green
+  };
+
+  const getRiskBackgroundColor = (risk: number) => {
+    if (risk >= 70) return '#FF4444';
+    if (risk >= 40) return '#FF8800';
+    return '#00D386';
+  };
+
+  return (
+    <div className="w-full h-full bg-dark-bg text-dark-text p-4 space-y-6 overflow-y-auto">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <button 
+            className="p-2 text-gray-400 hover:text-white"
+            onClick={onBack}
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
+          <h1 
+            style={{
+              fontFamily: 'Arial',
+              fontWeight: '700',
+              fontSize: '18px',
+              lineHeight: '24px',
+              letterSpacing: '0px',
+              color: '#E6E6E6'
+            }}
+          >
+            Transaction Analysis
+          </h1>
+        </div>
+        <button className="p-2 text-gray-400 hover:text-white">
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Table */}
+      <div className="bg-dark-card rounded-lg overflow-hidden">
+        {/* Table Header */}
+        <div className="grid grid-cols-5 gap-4 p-4 border-b border-dark-border">
+          <div 
+            style={{
+              fontFamily: 'Arial',
+              fontWeight: '400',
+              fontSize: '12px',
+              lineHeight: '16px',
+              letterSpacing: '0px',
+              color: '#E6E6E6'
+            }}
+          >
+            ADDRESS
+          </div>
+          <div 
+            style={{
+              fontFamily: 'Arial',
+              fontWeight: '400',
+              fontSize: '12px',
+              lineHeight: '16px',
+              letterSpacing: '0px',
+              color: '#E6E6E6'
+            }}
+          >
+            AMOUNT
+          </div>
+          <div 
+            style={{
+              fontFamily: 'Arial',
+              fontWeight: '400',
+              fontSize: '12px',
+              lineHeight: '16px',
+              letterSpacing: '0px',
+              color: '#E6E6E6'
+            }}
+          >
+            NETWORK
+          </div>
+          <div 
+            style={{
+              fontFamily: 'Arial',
+              fontWeight: '400',
+              fontSize: '12px',
+              lineHeight: '16px',
+              letterSpacing: '0px',
+              color: '#E6E6E6'
+            }}
+          >
+            RISK
+          </div>
+          <div 
+            style={{
+              fontFamily: 'Arial',
+              fontWeight: '400',
+              fontSize: '12px',
+              lineHeight: '16px',
+              letterSpacing: '0px',
+              color: '#E6E6E6'
+            }}
+          >
+            DATE
+          </div>
+        </div>
+
+        {/* Table Rows */}
+        <div className="divide-y divide-dark-border">
+          {transactions.map((transaction) => (
+            <div key={transaction.id} className="grid grid-cols-5 gap-4 p-4 hover:bg-dark-bg/50 transition-colors cursor-pointer">
+              <div className="flex items-center gap-3">
+                {getStatusIcon(transaction.status)}
+                <span 
+                  style={{
+                    fontFamily: 'Arial',
+                    fontWeight: '400',
+                    fontSize: '14px',
+                    lineHeight: '20px',
+                    letterSpacing: '0px',
+                    color: '#E6E6E6'
+                  }}
+                >
+                  {transaction.address}
+                </span>
+              </div>
+              <div 
+                style={{
+                  fontFamily: 'Arial',
+                  fontWeight: '400',
+                  fontSize: '14px',
+                  lineHeight: '20px',
+                  letterSpacing: '0px',
+                  color: '#E6E6E6'
+                }}
+              >
+                {transaction.amount}
+              </div>
+              <div 
+                style={{
+                  fontFamily: 'Arial',
+                  fontWeight: '400',
+                  fontSize: '14px',
+                  lineHeight: '20px',
+                  letterSpacing: '0px',
+                  color: '#E6E6E6'
+                }}
+              >
+                {transaction.network}
+              </div>
+              <div className="flex items-center justify-between">
+                <span 
+                  className="px-2 py-1 rounded-full text-xs"
+                  style={{
+                    backgroundColor: getRiskBackgroundColor(transaction.risk),
+                    color: '#FFFFFF',
+                    fontFamily: 'Arial',
+                    fontWeight: '400',
+                    fontSize: '12px',
+                    lineHeight: '16px',
+                    letterSpacing: '0px'
+                  }}
+                >
+                  {transaction.risk}%
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span 
+                  style={{
+                    fontFamily: 'Arial',
+                    fontWeight: '400',
+                    fontSize: '14px',
+                    lineHeight: '20px',
+                    letterSpacing: '0px',
+                    color: '#E6E6E6'
+                  }}
+                >
+                  {transaction.date}
+                </span>
+                <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Pagination - Only show for Pro plan */}
+      {!isFreePlan && (
+        <div className="flex items-center justify-center gap-2">
+        <button 
+          className="p-2 text-gray-400 hover:text-white"
+          onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+        
+        <button 
+          className={`px-3 py-1 rounded ${
+            currentPage === 1 ? 'bg-gray-600' : 'bg-transparent'
+          }`}
+          onClick={() => setCurrentPage(1)}
+        >
+          <span 
+            style={{
+              fontFamily: 'Arial',
+              fontWeight: '400',
+              fontSize: '14px',
+              lineHeight: '20px',
+              letterSpacing: '0px',
+              color: '#E6E6E6'
+            }}
+          >
+            1
+          </span>
+        </button>
+        
+        <button 
+          className={`px-3 py-1 rounded ${
+            currentPage === 2 ? 'bg-gray-600' : 'bg-transparent'
+          }`}
+          onClick={() => setCurrentPage(2)}
+        >
+          <span 
+            style={{
+              fontFamily: 'Arial',
+              fontWeight: '400',
+              fontSize: '14px',
+              lineHeight: '20px',
+              letterSpacing: '0px',
+              color: '#E6E6E6'
+            }}
+          >
+            2
+          </span>
+        </button>
+        
+        <button 
+          className={`px-3 py-1 rounded ${
+            currentPage === 3 ? 'bg-gray-600' : 'bg-transparent'
+          }`}
+          onClick={() => setCurrentPage(3)}
+        >
+          <span 
+            style={{
+              fontFamily: 'Arial',
+              fontWeight: '400',
+              fontSize: '14px',
+              lineHeight: '20px',
+              letterSpacing: '0px',
+              color: '#E6E6E6'
+            }}
+          >
+            3
+          </span>
+        </button>
+        
+        <span 
+          style={{
+            fontFamily: 'Arial',
+            fontWeight: '400',
+            fontSize: '14px',
+            lineHeight: '20px',
+            letterSpacing: '0px',
+            color: '#858C94'
+          }}
+        >
+          ...
+        </span>
+        
+        <button 
+          className="px-3 py-1 rounded bg-transparent"
+          onClick={() => setCurrentPage(12)}
+        >
+          <span 
+            style={{
+              fontFamily: 'Arial',
+              fontWeight: '400',
+              fontSize: '14px',
+              lineHeight: '20px',
+              letterSpacing: '0px',
+              color: '#E6E6E6'
+            }}
+          >
+            12
+          </span>
+        </button>
+        
+        <button 
+          className="p-2 text-gray-400 hover:text-white"
+          onClick={() => setCurrentPage(Math.min(12, currentPage + 1))}
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+        </div>
+      )}
+
+      {/* Free Plan Upgrade Section - Only show for Free plan */}
+      {isFreePlan && (
+        <div className="border border-yellow-500 rounded-lg p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <p 
+              style={{
+                fontFamily: 'Arial',
+                fontWeight: '400',
+                fontSize: '14px',
+                lineHeight: '20px',
+                letterSpacing: '0px',
+                color: '#E6E6E6',
+                marginBottom: '4px'
+              }}
+            >
+              Limited history (last 3 transactions)
+            </p>
+            <p 
+              style={{
+                fontFamily: 'Arial',
+                fontWeight: '400',
+                fontSize: '12px',
+                lineHeight: '16px',
+                letterSpacing: '0px',
+                color: '#858C94'
+              }}
+            >
+              Upgrade to Pro for full access to history
+            </p>
+          </div>
+          <button 
+            className="px-4 py-2 rounded-lg transition-colors"
+            style={{
+              backgroundColor: '#FBB500',
+              color: '#1A141F',
+              fontFamily: 'Arial',
+              fontWeight: '700',
+              fontSize: '14px',
+              lineHeight: '20px',
+              letterSpacing: '0px'
+            }}
+            onClick={onNavigateToPlans}
+          >
+            View Plans
+          </button>
+        </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default History;

--- a/frontend/extension/src/store/transaction-store.ts
+++ b/frontend/extension/src/store/transaction-store.ts
@@ -1,0 +1,49 @@
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import type { Transaction } from '../types/transaction';
+
+interface TransactionState {
+  transactions: Transaction[];
+  currentTransaction: Transaction | null;
+  
+  // Actions
+  addTransaction: (transaction: Transaction) => void;
+  updateTransaction: (id: string, updates: Partial<Transaction>) => void;
+  setCurrentTransaction: (transaction: Transaction | null) => void;
+  clearTransactions: () => void;
+}
+
+export const useTransactionStore = create<TransactionState>()(
+  immer((set) => ({
+    transactions: [],
+    currentTransaction: null,
+
+    addTransaction: (transaction) =>
+      set((state) => {
+        state.transactions.unshift(transaction);
+        // Keep only last 100 transactions
+        if (state.transactions.length > 100) {
+          state.transactions = state.transactions.slice(0, 100);
+        }
+      }),
+
+    updateTransaction: (id, updates) =>
+      set((state) => {
+        const index = state.transactions.findIndex((t) => t.id === id);
+        if (index !== -1) {
+          state.transactions[index] = { ...state.transactions[index], ...updates };
+        }
+      }),
+
+    setCurrentTransaction: (transaction) =>
+      set((state) => {
+        state.currentTransaction = transaction;
+      }),
+
+    clearTransactions: () =>
+      set((state) => {
+        state.transactions = [];
+      }),
+  }))
+);
+


### PR DESCRIPTION
- Add History.tsx page with transaction history display
- Implement transaction-store.ts for state management
- Display transaction table with columns: ADDRESS, AMOUNT, NETWORK, RISK, DATE
- Add status icons (forbidden, success, warning) with color coding
- Implement pagination controls for transaction navigation
- Add Free plan limitations (last 3 transactions only)
- Include upgrade section for Pro plan with 'View Plans' button
- Add risk score pills with color coding (High, Medium, Low)
- Implement responsive design for 420x600px popup
- Add back navigation and proper routing
- Support for different transaction statuses and risk levels

Resolves #18